### PR TITLE
Remove ProblemType from Problem model and persistence

### DIFF
--- a/src/CombinatoricsService/Api/Endpoints/V1/Problems/CreateProblem.cs
+++ b/src/CombinatoricsService/Api/Endpoints/V1/Problems/CreateProblem.cs
@@ -25,8 +25,7 @@ public sealed class CreateProblemEndpoint : IEndpoint
     {
         Result<CreateProblemResult> result = await mediator.Send(new CreateProblemCommand(
             request.Name,
-            request.Description ?? string.Empty,
-            request.ProblemType
+            request.Description ?? string.Empty
         ), cancellationToken);
 
         if (result.IsSuccess)
@@ -44,8 +43,6 @@ public sealed class CreateProblemRequest
     public string Name { get; set; } = null!;
 
     public string? Description { get; set; }
-
-    public string ProblemType { get; set; } = null!;
 }
 
 public sealed record CreateProblemResponse(Guid ProblemId);

--- a/src/CombinatoricsService/Application/Features/Problems/BooleanSatisfiability/BooleanSatisfiabilityInstanceDto.cs
+++ b/src/CombinatoricsService/Application/Features/Problems/BooleanSatisfiability/BooleanSatisfiabilityInstanceDto.cs
@@ -1,4 +1,10 @@
-﻿namespace Raijin.CombinatoricsService.Application.Features.Problems.BooleanSatisfiability;
+﻿using System.Text.Json.Serialization;
+using Raijin.CombinatoricsService.Domain.Problems;
+
+namespace Raijin.CombinatoricsService.Application.Features.Problems.BooleanSatisfiability;
 
 public record BooleanSatisfiabilityInstanceDto(IEnumerable<IEnumerable<int>> Clauses)
-    : InstanceDto;
+    : InstanceDto
+{
+    [JsonIgnore] public override string ProblemType => ProblemTypes.BooleanSatisfiabilityProblem;
+}

--- a/src/CombinatoricsService/Application/Features/Problems/CreateProblem.cs
+++ b/src/CombinatoricsService/Application/Features/Problems/CreateProblem.cs
@@ -16,7 +16,7 @@ public sealed class CreateProblemHandler(
         CancellationToken cancellationToken)
     {
         var id = Guid.CreateVersion7();
-        var problem = Problem.Create(id, request.Name, request.Description, request.ProblemType);
+        var problem = Problem.Create(id, request.Name, request.Description);
 
         await problemRepository.Add(problem, cancellationToken);
         await unitOfWork.Commit(cancellationToken);
@@ -27,8 +27,7 @@ public sealed class CreateProblemHandler(
 
 public sealed record CreateProblemCommand(
     string Name,
-    string Description,
-    string ProblemType
+    string Description
 ) : IRequest<CreateProblemResult>;
 
 public sealed record CreateProblemResult(
@@ -45,10 +44,5 @@ public sealed class CreateProblemValidator : AbstractValidator<CreateProblemComm
         RuleFor(command => command.Description)
             .NotNull()
             .MaximumLength(5000);
-        RuleFor(command => command.ProblemType)
-            .NotEmpty()
-            .MaximumLength(100)
-            .Must(ProblemTypes.IsValid)
-            .WithMessage($"The valid problem types are: {string.Join(", ", ProblemTypes.GetAll())}");
     }
 }

--- a/src/CombinatoricsService/Application/Features/Problems/SetProblemInstance.cs
+++ b/src/CombinatoricsService/Application/Features/Problems/SetProblemInstance.cs
@@ -27,11 +27,11 @@ public sealed class SetProblemInstanceCommandHandler(
             return new NotFoundError(nameof(Problem), request.ProblemId);
 
         IInstanceFactory? instanceFactory = problemInstanceFactories
-            .FirstOrDefault(factory => factory.ProblemType == problem.ProblemType);
+            .FirstOrDefault(factory => factory.ProblemType == request.Instance.ProblemType);
 
         if (instanceFactory is null)
             throw new InvalidOperationException(
-                $"No instance factory found for problem type {problem.ProblemType}");
+                $"No instance factory found for problem type {request.Instance.ProblemType}");
 
         Result<Instance> instanceResult = instanceFactory.CreateInstance(request.Instance);
 
@@ -61,7 +61,10 @@ public sealed record SetProblemInstanceCommand(
 
 [JsonPolymorphic]
 [JsonDerivedType(typeof(BooleanSatisfiabilityInstanceDto), ProblemTypes.BooleanSatisfiabilityProblem)]
-public abstract record InstanceDto;
+public abstract record InstanceDto
+{
+    public abstract string ProblemType { get; }
+}
 
 public sealed class SetProblemInstanceValidator : AbstractValidator<SetProblemInstanceCommand>
 {

--- a/src/CombinatoricsService/Domain/Problems/Problem.cs
+++ b/src/CombinatoricsService/Domain/Problems/Problem.cs
@@ -2,12 +2,11 @@
 
 public sealed class Problem
 {
-    private Problem(Guid id, string name, string description, string problemType)
+    private Problem(Guid id, string name, string description)
     {
         Id = id;
         Name = name;
         Description = description;
-        ProblemType = problemType;
     }
 
     public Guid Id { get; }
@@ -15,8 +14,6 @@ public sealed class Problem
     public string Name { get; private set; }
 
     public string Description { get; private set; }
-
-    public string ProblemType { get; }
 
     public Instance? Instance { get; private set; }
 
@@ -26,31 +23,27 @@ public sealed class Problem
 
     public Solution? Solution { get; private set; }
 
-    public static Problem Create(Guid id, string name, string description, string problemType)
+    public static Problem Create(Guid id, string name, string description)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
         ArgumentNullException.ThrowIfNull(description);
-        ArgumentException.ThrowIfNullOrWhiteSpace(problemType);
 
         if (name.Length > 100)
             throw new ArgumentException("Name cannot exceed 100 characters", nameof(name));
         if (description.Length > 5000)
             throw new ArgumentException("Description cannot exceed 1000 characters", nameof(description));
-        if (problemType.Length > 100)
-            throw new ArgumentException("Problem kind cannot exceed 100 characters", nameof(problemType));
 
-        return new Problem(id, name, description, problemType);
+        return new Problem(id, name, description);
     }
 
     public static Problem Rehydrate(Guid id,
         string name,
         string description,
-        string problemType,
         Instance? instance,
         SatEncoding? satEncoding,
         SatRun? satRun,
         Solution? solution
-    ) => new(id, name, description, problemType)
+    ) => new(id, name, description)
     {
         Instance = instance,
         SatEncoding = satEncoding,
@@ -81,11 +74,6 @@ public sealed class Problem
     public void SetInstance(Instance instance)
     {
         ArgumentNullException.ThrowIfNull(instance);
-        if (instance.ProblemType() != ProblemType)
-            throw new ArgumentException(
-                $"Instance problem kind '{instance.ProblemType}' does not match problem type '{ProblemType}'",
-                nameof(instance)
-            );
 
         Instance = instance;
         SatEncoding = null!;

--- a/src/CombinatoricsService/Infrastructure/Persistence/Configurations/ProblemModelConfiguration.cs
+++ b/src/CombinatoricsService/Infrastructure/Persistence/Configurations/ProblemModelConfiguration.cs
@@ -18,10 +18,6 @@ internal sealed class ProblemModelConfiguration : IEntityTypeConfiguration<Probl
             .IsRequired()
             .HasMaxLength(5000);
 
-        builder.Property(problem => problem.ProblemType)
-            .IsRequired()
-            .HasMaxLength(100);
-
         builder.Property(problem => problem.Instance)
             .HasColumnType("jsonb");
 

--- a/src/CombinatoricsService/Infrastructure/Persistence/Migrations/20260406003526_RemovedProblemKind.Designer.cs
+++ b/src/CombinatoricsService/Infrastructure/Persistence/Migrations/20260406003526_RemovedProblemKind.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Raijin.CombinatoricsService.Infrastructure.Persistence;
@@ -12,9 +13,11 @@ using Raijin.CombinatoricsService.Infrastructure.Persistence;
 namespace Raijin.CombinatoricsService.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(CombinatoricsServiceDbContext))]
-    partial class CombinatoricsServiceDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260406003526_RemovedProblemKind")]
+    partial class RemovedProblemKind
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/CombinatoricsService/Infrastructure/Persistence/Migrations/20260406003526_RemovedProblemKind.cs
+++ b/src/CombinatoricsService/Infrastructure/Persistence/Migrations/20260406003526_RemovedProblemKind.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Raijin.CombinatoricsService.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemovedProblemKind : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ProblemType",
+                table: "Problems");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ProblemType",
+                table: "Problems",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: false,
+                defaultValue: "");
+        }
+    }
+}

--- a/src/CombinatoricsService/Infrastructure/Persistence/Models/ProblemModel.cs
+++ b/src/CombinatoricsService/Infrastructure/Persistence/Models/ProblemModel.cs
@@ -10,8 +10,6 @@ internal class ProblemModel
 
     public string Description { get; set; }
 
-    public string ProblemType { get; set; }
-
     public JsonDocument Instance { get; set; }
 
     public JsonDocument Solution { get; set; }

--- a/src/CombinatoricsService/Infrastructure/Persistence/Repositories/ProblemRepository.cs
+++ b/src/CombinatoricsService/Infrastructure/Persistence/Repositories/ProblemRepository.cs
@@ -18,7 +18,6 @@ public class ProblemRepository(CombinatoricsServiceDbContext dbContext) : IProbl
             model.Id,
             model.Name,
             model.Description,
-            model.ProblemType,
             model.Instance is { } instance ? instance.Deserialize<Instance>() : null,
             model.SatEncoding is { } encoding
                 ? SatEncoding.Rehydrate(
@@ -48,7 +47,6 @@ public class ProblemRepository(CombinatoricsServiceDbContext dbContext) : IProbl
             Id = problem.Id,
             Name = problem.Name,
             Description = problem.Description,
-            ProblemType = problem.ProblemType,
             Instance = JsonSerializer.SerializeToDocument(problem.Instance),
             SatEncoding = problem.SatEncoding is { } encoding
                 ? new SatEncodingModel
@@ -87,7 +85,6 @@ public class ProblemRepository(CombinatoricsServiceDbContext dbContext) : IProbl
 
         model.Name = problem.Name;
         model.Description = problem.Description;
-        model.ProblemType = problem.ProblemType;
         model.Instance = JsonSerializer.SerializeToDocument(problem.Instance);
         model.SatEncoding = problem.SatEncoding is { } encoding
             ? new SatEncodingModel


### PR DESCRIPTION
Remove ProblemType from Problem model and persistence

ProblemType is no longer a property of the Problem entity or its persistence model. All related API, validation, and repository logic has been updated to remove references to ProblemType. The database schema is migrated to drop the ProblemType column. Problem type is now determined by the instance data (InstanceDto) rather than stored on the Problem itself.